### PR TITLE
Add FASTA upload option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ pip install streamlit py3Dmol stmol pandas biopython plotly kaleido scipy biopan
 
 To run SPACE execute the following command:
 
-```bash 
+```bash
 streamlit run app.py
 ```
+
+When launching the app you can now provide sequences from NCBI, UniProt or by uploading your own FASTA file. Choose **Upload FASTA** in the data source selector and then provide a file containing the sequences you wish to analyze.
 

--- a/space/pdb_processing.py
+++ b/space/pdb_processing.py
@@ -55,6 +55,7 @@ def process_pdb_chain(
     uniprot_id: str = None,
     own_pdb: str = None,
     st_column: Optional = None,
+    output_dir: str = "PDB_processing",
 ) -> dict:
     """
     Processes a protein sequence to find matching PDB chains, maps al2co scores,
@@ -98,7 +99,7 @@ def process_pdb_chain(
         }
     elif uniprot_id:
         # Download AlphaFold PDB
-        if download_alphafold_pdb(uniprot_id):
+        if download_alphafold_pdb(uniprot_id, save_dir=output_dir):
             pdb_filename = f"selected.pdb"
             selected_pdb = uniprot_id
             uniprot_meta_data = get_protein_data(uniprot_id)
@@ -258,7 +259,6 @@ def process_pdb_chain(
         raise ValueError("No valid chains found.")
 
     # Initialize a directory to save updated PDB files
-    output_dir = "PDB_processing"
     os.makedirs(output_dir, exist_ok=True)
 
     chain_data = {}

--- a/space/visualization.py
+++ b/space/visualization.py
@@ -1,5 +1,6 @@
 # visualization.py
 
+import os
 import re
 import numpy as np
 import pandas as pd
@@ -63,8 +64,7 @@ def visualize_al2co_seaborn(al2co_df: pd.DataFrame):
     cbar.set_label("Conservation Score")
 
     st.pyplot(fig)
-
-def visualize_al2co_plotly(al2co_df: pd.DataFrame):
+def visualize_al2co_plotly(al2co_df: pd.DataFrame, folder: str = "."):
     """
     Visualizes al2co conservation scores using Plotly with a customized colorscale.
 
@@ -137,7 +137,7 @@ def visualize_al2co_plotly(al2co_df: pd.DataFrame):
         hovermode="closest",
         height=600,
     )
-    fig.write_html("al2co_plot.html")
+    fig.write_html(os.path.join(folder, "al2co_plot.html"))
 
     st.plotly_chart(fig, use_container_width=True)
 


### PR DESCRIPTION
## Summary
- add option to upload FASTA sequences
- process uploaded FASTA file as input
- document FASTA upload in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687abeda36ac832ea0ebf7d4020d2e02